### PR TITLE
[Feat] Home - SideBar UI 구현 완료

### DIFF
--- a/youtube-ari/src/components/Header/HeaderLogo.jsx
+++ b/youtube-ari/src/components/Header/HeaderLogo.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import logo from "../../assets/youtube-logo.svg";
 
 const HeaderLogo = () => {

--- a/youtube-ari/src/components/Header/HeaderLogo.jsx
+++ b/youtube-ari/src/components/Header/HeaderLogo.jsx
@@ -3,9 +3,9 @@ import logo from "../../assets/youtube-logo.svg";
 const HeaderLogo = () => {
   return (
     <div className="flex items-center">
-      <a href="/" title="Youtube Home" className="px-4 py-[18px]">
+      <Link to="/" title="Youtube Home" className="px-4 py-[18px]">
         <img src={logo} alt="YouTube Logo" className="h-full w-full" />
-      </a>
+      </Link>
     </div>
   );
 };

--- a/youtube-ari/src/components/Header/HeaderSearchBar.jsx
+++ b/youtube-ari/src/components/Header/HeaderSearchBar.jsx
@@ -29,7 +29,7 @@ const HeaderSearchBar = () => {
         <button
           aria-label="Search Btn"
           title="Search"
-          className="border-bdDefault bg-bgDefault hover:bg-bgHover w-16 rounded-r-[40px] border"
+          className="border-ytGray-60 bg-ytGray-10 hover:bg-ytGray-20 hover:border-ytGray-70 w-16 rounded-r-[40px] border"
         >
           <Search
             alt="Search Btn"
@@ -38,7 +38,7 @@ const HeaderSearchBar = () => {
           />
         </button>
       </div>
-      <div className="hover:bg-bgHover bg-bgDefault group relative ml-3 rounded-full">
+      <div className="bg-ytGray-30 hover:bg-ytGray-50 group relative ml-3 rounded-full">
         <button className="inline-flex h-10 w-10 items-center justify-center rounded-full">
           <Mic strokeWidth={1.25} alt="Voice Search Btn" className="h-6 w-6" />
         </button>

--- a/youtube-ari/src/components/SideBar.jsx
+++ b/youtube-ari/src/components/SideBar.jsx
@@ -1,3 +1,5 @@
+import { House, UserCircle } from "lucide-react";
+
 const SideBar = () => {
   return (
     <div className="fixed bottom-0 left-0 top-14 z-[2028] box-border inline-block w-[72px] px-1">
@@ -9,7 +11,7 @@ const SideBar = () => {
             className="flex w-16 flex-col items-center justify-center py-4 outline-none"
           >
             <div className="mb-[6px]">
-              <img src="" alt="" className="h-6 w-6" />
+              <House alt="Home Page" strokeWidth={1.5} className="h-6 w-6" />
             </div>
             <span className="block max-w-full overflow-ellipsis whitespace-nowrap text-[10px] font-normal">
               Home
@@ -23,7 +25,11 @@ const SideBar = () => {
             className="flex w-16 flex-col items-center justify-center pb-[14px] pt-4 outline-none"
           >
             <div className="mb-2">
-              <img src="" alt="" className="h-6 w-6" />
+              <UserCircle
+                alt="User Page"
+                strokeWidth={1.5}
+                className="h-6 w-6"
+              />
             </div>
             <span className="block max-w-full overflow-ellipsis whitespace-nowrap text-[10px] font-normal">
               You

--- a/youtube-ari/src/components/SideBar.jsx
+++ b/youtube-ari/src/components/SideBar.jsx
@@ -5,26 +5,16 @@ const SideBar = () => {
   return (
     <div className="fixed bottom-0 left-0 top-14 z-[2028] box-border inline-block w-[72px] px-1">
       <div className="mt-1 flex flex-col">
-        <div className="relative inline-block rounded-lg bg-transparent hover:bg-[#f2f2f2] active:bg-[#d9d9d9]">
-          <Link
-            to="/"
-            title="Home"
-            className="flex w-16 flex-col items-center justify-center py-4 outline-none"
-          >
-            <div className="mb-[6px]">
+        <div className="sidebarIconWrapper">
+          <Link to="/" title="Home" className="sidebarIconLink">
+            <div className="mb-2">
               <House alt="Home Page" strokeWidth={1.5} className="h-6 w-6" />
             </div>
-            <span className="block max-w-full overflow-ellipsis whitespace-nowrap text-[10px] font-normal">
-              Home
-            </span>
+            <span className="sidebarIconText">Home</span>
           </Link>
         </div>
-        <div className="relative inline-block rounded-lg bg-transparent hover:bg-[#f2f2f2] active:bg-[#d9d9d9]">
-          <Link
-            to="/"
-            title="You"
-            className="flex w-16 flex-col items-center justify-center pb-[14px] pt-4 outline-none"
-          >
+        <div className="sidebarIconWrapper">
+          <Link to="/" title="You" className="sidebarIconLink">
             <div className="mb-2">
               <UserCircle
                 alt="User Page"
@@ -32,9 +22,7 @@ const SideBar = () => {
                 className="h-6 w-6"
               />
             </div>
-            <span className="block max-w-full overflow-ellipsis whitespace-nowrap text-[10px] font-normal">
-              You
-            </span>
+            <span className="sidebarIconText">You</span>
           </Link>
         </div>
       </div>

--- a/youtube-ari/src/components/SideBar.jsx
+++ b/youtube-ari/src/components/SideBar.jsx
@@ -1,0 +1,38 @@
+const SideBar = () => {
+  return (
+    <div className="fixed bottom-0 left-0 top-14 z-[2028] box-border inline-block w-[72px] px-1">
+      <div className="mt-1 flex flex-col">
+        <div className="relative inline-block rounded-lg bg-transparent hover:bg-[#f2f2f2] active:bg-[#d9d9d9]">
+          <a
+            href="/"
+            title="Home"
+            className="flex w-16 flex-col items-center justify-center py-4 outline-none"
+          >
+            <div className="mb-[6px]">
+              <img src="" alt="" className="h-6 w-6" />
+            </div>
+            <span className="block max-w-full overflow-ellipsis whitespace-nowrap text-[10px] font-normal">
+              Home
+            </span>
+          </a>
+        </div>
+        <div className="relative inline-block rounded-lg bg-transparent hover:bg-[#f2f2f2] active:bg-[#d9d9d9]">
+          <a
+            href="/"
+            title="You"
+            className="flex w-16 flex-col items-center justify-center pb-[14px] pt-4 outline-none"
+          >
+            <div className="mb-2">
+              <img src="" alt="" className="h-6 w-6" />
+            </div>
+            <span className="block max-w-full overflow-ellipsis whitespace-nowrap text-[10px] font-normal">
+              You
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SideBar;

--- a/youtube-ari/src/components/SideBar.jsx
+++ b/youtube-ari/src/components/SideBar.jsx
@@ -5,8 +5,8 @@ const SideBar = () => {
     <div className="fixed bottom-0 left-0 top-14 z-[2028] box-border inline-block w-[72px] px-1">
       <div className="mt-1 flex flex-col">
         <div className="relative inline-block rounded-lg bg-transparent hover:bg-[#f2f2f2] active:bg-[#d9d9d9]">
-          <a
-            href="/"
+          <Link
+            to="/"
             title="Home"
             className="flex w-16 flex-col items-center justify-center py-4 outline-none"
           >
@@ -16,11 +16,11 @@ const SideBar = () => {
             <span className="block max-w-full overflow-ellipsis whitespace-nowrap text-[10px] font-normal">
               Home
             </span>
-          </a>
+          </Link>
         </div>
         <div className="relative inline-block rounded-lg bg-transparent hover:bg-[#f2f2f2] active:bg-[#d9d9d9]">
-          <a
-            href="/"
+          <Link
+            to="/"
             title="You"
             className="flex w-16 flex-col items-center justify-center pb-[14px] pt-4 outline-none"
           >
@@ -34,7 +34,7 @@ const SideBar = () => {
             <span className="block max-w-full overflow-ellipsis whitespace-nowrap text-[10px] font-normal">
               You
             </span>
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/youtube-ari/src/components/SideBar.jsx
+++ b/youtube-ari/src/components/SideBar.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { House, UserCircle } from "lucide-react";
 
 const SideBar = () => {

--- a/youtube-ari/src/components/ThemeToggleSwitch.jsx
+++ b/youtube-ari/src/components/ThemeToggleSwitch.jsx
@@ -4,14 +4,18 @@ import { Sun, Moon } from "lucide-react";
 export default function ThemeToggleSwitch() {
   const [theme, setTheme] = useState("light");
 
-  const toggleTheme = () => {
+  const themeToggle = () => {
     setTheme((prev) => (prev === "light" ? "dark" : "light"));
   };
+
+  const themeToggleTitle =
+    theme === "dark" ? "Switch to light theme" : "Switch to dark theme";
 
   return (
     <div className="mr-2 px-2">
       <button
-        onClick={toggleTheme}
+        onClick={themeToggle}
+        title={themeToggleTitle}
         className={`flex h-8 w-14 items-center rounded-full p-1 transition-colors duration-300 ${theme === "dark" ? "bg-gray-700 outline outline-1 outline-white" : "bg-gray-200"}`}
       >
         <div

--- a/youtube-ari/src/index.css
+++ b/youtube-ari/src/index.css
@@ -43,4 +43,16 @@ button {
   @apply shadow-[0_0_0_1px_#1c62b9];
 }
 
+.sidebarIconWrapper {
+  @apply hover:bg-ytGray-30 active:bg-ytGray-50 relative inline-block rounded-lg bg-transparent;
+}
+
+.sidebarIconLink {
+  @apply flex w-16 flex-col items-center justify-center py-4 outline-none;
+}
+
+.sidebarIconText {
+  @apply block max-w-full overflow-ellipsis whitespace-nowrap text-[10px] font-normal;
+}
+
 @tailwind utilities;

--- a/youtube-ari/src/index.css
+++ b/youtube-ari/src/index.css
@@ -15,15 +15,15 @@ button {
 @tailwind components;
 
 .searchContainer {
-  @apply border-bdDefault relative ml-8 flex flex-1 cursor-text items-center rounded-[40px_0_0_40px] border border-r-0 bg-white pl-4 pr-1 shadow-[inset_0_1px_2px_#eee];
+  @apply border-ytGray-70 relative ml-8 flex flex-1 cursor-text items-center rounded-[40px_0_0_40px] border border-r-0 bg-white pl-4 pr-1 shadow-[inset_0_1px_2px_#eee];
 }
 
 .searchContainer:focus-within {
-  @apply border-bdFocus ml-0 border-r py-[2px] pl-12 pr-1 shadow-[inset_0_1px_2px_rgba(0,0,0,0.3)];
+  @apply ml-0 border-r border-[#1c62b9] py-[2px] pl-12 pr-1 shadow-[inset_0_1px_2px_rgba(0,0,0,0.3)];
 }
 
 .tooltip {
-  @apply pointer-events-none absolute z-[1002] m-2 whitespace-nowrap rounded-sm bg-[#616161] p-2 text-xs text-white;
+  @apply bg-ytGray-90 pointer-events-none absolute z-[1002] m-2 whitespace-nowrap rounded-sm p-2 text-xs text-white;
   @apply tooltipAnimation;
 }
 

--- a/youtube-ari/src/pages/Home.jsx
+++ b/youtube-ari/src/pages/Home.jsx
@@ -1,12 +1,12 @@
 import Header from "../components/Header/Header";
+import SideBar from "../components/SideBar";
 
 const Home = () => {
   return (
     <div>
       <Header />
-      <div className="h-[2000px] bg-gray-100 pt-14">
-        Scroll to test fixed header
-      </div>
+      <SideBar />
+      <div className="ml-[72px] mt-14 h-[2000px] bg-gray-100">content</div>
     </div>
   );
 };

--- a/youtube-ari/tailwind.config.js
+++ b/youtube-ari/tailwind.config.js
@@ -7,10 +7,16 @@ export default {
         sans: ["Roboto", "Arial", "sans-serif"], // 기본 sans에 Roboto 설정
       },
       colors: {
-        bdDefault: "#c6c6c6",
-        bdFocus: "#1c62b9",
-        bgDefault: "#f2f2f2",
-        bgHover: "#d9d9d9",
+        ytGray: {
+          10: "#f8f8f8",
+          20: "#f0f0f0",
+          30: "#f2f2f2",
+          40: "#e5e5e5",
+          50: "#d9d9d9",
+          60: "#d3d3d3",
+          70: "#c6c6c6",
+          90: "#616161",
+        },
       },
     },
   },


### PR DESCRIPTION
### ✅ 변경사항
#### 1. SideBar
- `lucide-react`의 `House`, `UserCircle` 아이콘 사용
- `Link` 컴포넌트를 활용해 홈(Home), 유저(You) 버튼 구현 및 라우팅 처리
- `.sidebarIconWrapper`에 hover, active 상태별 배경색 스타일 지정
- `.sidebarIconText`에 `ellipsis`, `whitespace-nowrap` 처리로 텍스트 오버플로우 제어

---
### 💡기존 페이지와 다른 추가 변경 사항
#### 1. 커스텀 색상 변수
- 기능명이 아닌 색상 코드 기반의 네이밍 방식 도입 (`ytGray-10`, `ytGray-20`, …)
- 재사용성과 유지보수를 고려해 Tailwind 커스텀 컬러 변수 형태로 지정

#### 2. lucide 아이콘 커스터마이징
- `lucide-react` 아이콘을 사용하여 Home/User 페이지에 적절히 적용
- 현재 페이지 여부에 따라 `fill` 속성 대신 `stroke` 또는 `color`를 사용해 상태 표현 예정 (gray 등)

---
### ⭐ 이후 수정 사항
- 모바일 화면 크기일 때 SideBar는 보이지 않게 설정
- 현재 페이지 여부에 따른 버튼 활성화 #11 
