### PR TITLE
[Feat] 연관 영상 API 연동 및 UI 교체 완료

### DIFF
--- a/youtube-ari/src/App.jsx
+++ b/youtube-ari/src/App.jsx
@@ -3,6 +3,7 @@ import "./App.css";
 import { Route, Routes } from "react-router-dom";
 
 import Header from "./components/Header/Header";
+import ScrollToTop from "./components/common/ScrollToTop";
 import Home from "./pages/Home";
 import MyPage from "./pages/MyPage";
 import VideoDetail from "./pages/VideoDetail";
@@ -13,6 +14,7 @@ function App() {
   return (
     <div className="min-h-screen bg-white text-black dark:bg-darkBg dark:text-white">
       <Header />
+      <ScrollToTop />
       <Routes>
         <Route element={<LayoutWithSidebar />}>
           <Route path="/" element={<Home />} />

--- a/youtube-ari/src/api/youtube.js
+++ b/youtube-ari/src/api/youtube.js
@@ -85,3 +85,65 @@ export const searchVideos = async (query, maxResults = 20) => {
     throw error;
   }
 };
+
+/**
+ * (대체) 연관 영상: 제목/태그/카테고리 기반 유사 검색
+ * relatedToVideoId는 더 이상 지원되지 않아 INVALID_ARGUMENT(400) 발생.
+ * - query: 제목/태그로 만든 질의어
+ * - categoryId: 기준 영상 categoryId
+ * - excludeChannelId: 같은 채널 과다 노출을 줄이고 싶을 때 제외
+ */
+export const searchSimilarVideos = async ({
+  query,
+  categoryId,
+  excludeChannelId,
+  maxResults = 20,
+  regionCode = "KR",
+}) => {
+  try {
+    const response = await youtube.get("/search", {
+      params: {
+        part: "snippet",
+        type: "video",
+        q: query,
+        videoCategoryId: categoryId || undefined,
+        regionCode,
+        maxResults: Math.min(Math.max(maxResults, 1), 50),
+        videoEmbeddable: "true",
+        relevanceLanguage: "ko",
+      },
+    });
+
+    const items = response.data.items || [];
+    return excludeChannelId
+      ? items.filter((it) => it.snippet?.channelId !== excludeChannelId)
+      : items;
+  } catch (error) {
+    console.error(
+      "Error searching similar videos >",
+      error?.response?.data || error,
+    );
+    throw error;
+  }
+};
+
+// 상세 보강용: 여러 ID 한 번에 조회 (통계/길이/전체 설명 포함)
+export const getVideosByIds = async (ids = []) => {
+  if (!ids.length) return [];
+  try {
+    const res = await youtube.get("/videos", {
+      params: {
+        part: "snippet,contentDetails,statistics",
+        id: ids.join(","),
+        maxResults: ids.length,
+      },
+    });
+    return res.data.items || [];
+  } catch (error) {
+    console.error(
+      "Error fetching videos by ids >",
+      error?.response?.data || error,
+    );
+    throw error;
+  }
+};

--- a/youtube-ari/src/components/VideoDetail/ChannelInfo.jsx
+++ b/youtube-ari/src/components/VideoDetail/ChannelInfo.jsx
@@ -1,14 +1,14 @@
-const ChannelInfo = ({ channelImage, channelName, handleChannelClick }) => {
+const ChannelInfo = ({ channelImage, channelName }) => {
   return (
-    <div
-      className="mt-3 flex cursor-pointer select-none flex-row items-center"
-      onClick={handleChannelClick}
-    >
+    <div className="mt-3 flex cursor-pointer select-none flex-row items-center">
       <div className="mr-3 h-10 w-10">
         <img
-          src={channelImage}
+          src={channelImage || "/src/assets/default-avatar.png"}
           alt="Channel Image"
           className="rounded-full object-cover"
+          onError={(e) => {
+            e.currentTarget.src = "/src/assets/default-avatar.png";
+          }}
         />
       </div>
       <div

--- a/youtube-ari/src/components/common/ScrollToTop.jsx
+++ b/youtube-ari/src/components/common/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0); // 페이지 이동 시 스크롤 최상단으로 이동
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/youtube-ari/src/hooks/useSimilarVideos.js
+++ b/youtube-ari/src/hooks/useSimilarVideos.js
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import {
+  getVideoDetails,
+  searchSimilarVideos,
+  getVideosByIds,
+  getChannelImage,
+} from "../api/youtube";
+import { transformVideo } from "../utils/transformVideoData";
+
+// 유사 검색어 만들기 (title + tags 기반)
+const buildQuery = (title = "", tags = []) => {
+  const stopWords = new Set([
+    "official",
+    "mv",
+    "the",
+    "and",
+    "with",
+    "feat",
+    "live",
+    "방송",
+    "영상",
+  ]);
+  const fromTitle = title
+    .toLowerCase()
+    .replace(/[^\w가-힣\s]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 2 && !stopWords.has(w));
+  const fromTags = (tags || [])
+    .map((t) => String(t).toLowerCase())
+    .filter((w) => w.length > 1 && !stopWords.has(w));
+
+  const merged = Array.from(new Set([...fromTitle, ...fromTags]));
+  return merged.slice(0, 6).join(" ");
+};
+
+export const useSimilarVideos = (videoId) => {
+  const [videos, setVideos] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+
+    const run = async () => {
+      if (!videoId) {
+        setVideos([]);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+
+      try {
+        // 기준 영상 상세
+        const baseVideo = await getVideoDetails(videoId);
+        if (!baseVideo) throw new Error("Base video not found");
+
+        const title = baseVideo.snippet?.title || "";
+        const tags = baseVideo.snippet?.tags || [];
+        const categoryId = baseVideo.snippet?.categoryId || undefined;
+        const channelId = baseVideo.snippet?.channelId || undefined;
+
+        // 검색어 생성 후 유사 검색
+        const query = buildQuery(title, tags);
+        const similarList = await searchSimilarVideos({
+          query,
+          categoryId,
+          excludeChannelId: channelId,
+          maxResults: 20,
+        });
+
+        // videoId 배열 추출 + 현재 영상 제외
+        const ids = Array.from(
+          new Set(similarList.map((it) => it.id?.videoId).filter(Boolean)),
+        ).filter((id) => id !== videoId);
+
+        // 상세 보강
+        const details = await getVideosByIds(ids);
+
+        // 채널 이미지 붙이고 transform
+        const merged = await Promise.all(
+          details.map(async (v) => {
+            const channelImage = await getChannelImage(v.snippet.channelId);
+            return transformVideo({ ...v, channelImage });
+          }),
+        );
+
+        if (alive) setVideos(merged);
+      } catch (err) {
+        if (alive) setError(err);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    };
+
+    run();
+    return () => {
+      alive = false;
+    };
+  }, [videoId]);
+
+  return { videos, loading, error };
+};

--- a/youtube-ari/src/pages/VideoDetail.jsx
+++ b/youtube-ari/src/pages/VideoDetail.jsx
@@ -21,7 +21,7 @@ const VideoDetail = () => {
     error: apiError,
   } = useVideoDetail(cleanId);
 
-  // useRelatedVideos 커스텀 훅
+  // useSimilarVideos 커스텀 훅
   const {
     videos: relatedVideos,
     loading: relatedLoading,
@@ -46,23 +46,30 @@ const VideoDetail = () => {
       return;
     }
 
-    if (initialVideoData && initialVideoData.videoId === cleanId) {
-      // 1. initialVideoData가 있고 현재 URL의 ID와 일치하면 그 데이터를 바로 사용 (클릭을 통해 넘어온 경우)
+    // 초기 데이터가 있으면 일단 먼저 보여주고
+    if (initialVideoData?.videoId === cleanId) {
       setCurrentVideo(initialVideoData);
-      setLoading(false);
-    } else {
-      // 2. initialVideoData가 없거나 ID가 다르면 API 호출 결과를 기다림 (직접 URL 접근 또는 다른 비디오 클릭 시)
-      if (apiLoading) {
-        // 로딩 중이므로 별도 처리 없음 (로딩 상태는 이미 true)
-      } else if (apiError) {
-        setError(apiError);
-        setLoading(false);
-      } else if (apiFetchedVideoDetail) {
-        setCurrentVideo(apiFetchedVideoDetail);
-        setLoading(false);
-      }
+      // 로딩은 true 유지해서 API로 보강되면 자연스럽게 교체 가능
     }
-  }, [cleanId, initialVideoData, apiLoading, apiError, apiFetchedVideoDetail]);
+
+    // API 상태 반영
+    if (apiError) {
+      setError(apiError);
+      setLoading(false);
+      return;
+    }
+
+    // API가 오면 초기 데이터와 머지
+    if (apiFetchedVideoDetail) {
+      setCurrentVideo((prev) => {
+        // prev가 없으면 API 걸로 바로
+        if (!prev) return apiFetchedVideoDetail;
+        // 기존 초기데이터에 API 결과를 덮어쓰기
+        return { ...prev, ...apiFetchedVideoDetail };
+      });
+      setLoading(false);
+    }
+  }, [cleanId, initialVideoData, apiError, apiFetchedVideoDetail]);
 
   // 로딩 UI
   if (loading) {
@@ -90,10 +97,6 @@ const VideoDetail = () => {
       </div>
     );
   }
-
-  const handleChannelClick = () => {
-    // navigate(`/@${video.channelName}`);
-  };
 
   const {
     title,
@@ -125,7 +128,6 @@ const VideoDetail = () => {
               channelImage={channelImage}
               channelName={channelName}
               channelId={channelId}
-              handleChannelClick={handleChannelClick}
             />
             <Description
               views={views}

--- a/youtube-ari/src/pages/VideoDetail.jsx
+++ b/youtube-ari/src/pages/VideoDetail.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import { useVideoDetail } from "../hooks/useVideoDetail";
-import { usePopularVideos } from "../hooks/usePopularVideos";
+import { useSimilarVideos } from "../hooks/useSimilarVideos";
+import { sanitizeVideoId } from "../utils/videoId";
 
 import ChannelInfo from "../components/VideoDetail/ChannelInfo";
 import Description from "../components/VideoDetail/Description";
@@ -9,37 +10,43 @@ import RelatedVideos from "../components/VideoDetail/RelatedVideos";
 
 const VideoDetail = () => {
   const { id } = useParams();
+  const cleanId = sanitizeVideoId(id);
   const location = useLocation();
-  const initialVideoData = location.state?.video; // VideoCard에서 넘어온 데이터
+  const initialVideoData = location.state?.video; // VideoCard에서 넘어온 초기 데이터
 
   // useVideoDetail 커스텀 훅
   const {
     videoDetail: apiFetchedVideoDetail,
     loading: apiLoading,
     error: apiError,
-  } = useVideoDetail(id);
+  } = useVideoDetail(cleanId);
 
-  const { videos: popularVideos, error: popularError } = usePopularVideos();
+  // useRelatedVideos 커스텀 훅
+  const {
+    videos: relatedVideos,
+    loading: relatedLoading,
+    error: relatedError,
+  } = useSimilarVideos(cleanId);
 
-  // 현재 동영상 데이터, 로딩, 에러 상태 관리
-  const [currentVideo, setCurrentVideo] = useState(initialVideoData || null);
+  // 현재 재생 중인 비디오 상태
+  const [currentVideo, setCurrentVideo] = useState(initialVideoData);
   const [loading, setLoading] = useState(!initialVideoData);
   const [error, setError] = useState(null);
 
-  // useEffect: id 또는 initialVideoData, API 응답에 따라 currentVideo 및 로딩/에러 상태 관리
+  // id/초기데이터/API 응답에 따라 현재 비디오 결정
   useEffect(() => {
     setLoading(true); // 새 비디오 로딩 시작
     setError(null); // 에러 초기화
     setCurrentVideo(null); // 이전 비디오 정보 초기화
 
-    if (!id) {
+    if (!cleanId) {
       // ID가 없는 경우 (잘못된 URL 접근)
       setError(new Error("Video ID is missing."));
       setLoading(false);
       return;
     }
 
-    if (initialVideoData && initialVideoData.videoId === id) {
+    if (initialVideoData && initialVideoData.videoId === cleanId) {
       // 1. initialVideoData가 있고 현재 URL의 ID와 일치하면 그 데이터를 바로 사용 (클릭을 통해 넘어온 경우)
       setCurrentVideo(initialVideoData);
       setLoading(false);
@@ -55,14 +62,7 @@ const VideoDetail = () => {
         setLoading(false);
       }
     }
-  }, [id, initialVideoData, apiLoading, apiError, apiFetchedVideoDetail]);
-
-  // Related video 목록 (자기 자신 제외)
-  const randomVideos = popularVideos
-    ? popularVideos
-        .filter((v) => v.videoId !== id)
-        .sort(() => Math.random() - 0.5)
-    : [];
+  }, [cleanId, initialVideoData, apiLoading, apiError, apiFetchedVideoDetail]);
 
   // 로딩 UI
   if (loading) {
@@ -112,7 +112,7 @@ const VideoDetail = () => {
           <div className="aspect-video min-h-[320px] min-w-[640px] overflow-hidden rounded-lg">
             <iframe
               className="h-full w-full"
-              src={`https://www.youtube.com/embed/${id}?autoplay=1`}
+              src={`https://www.youtube.com/embed/${cleanId}?autoplay=1`}
               title={title}
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               referrerPolicy="strict-origin-when-cross-origin"
@@ -137,7 +137,11 @@ const VideoDetail = () => {
 
         {/* 추천영상 */}
         <div className="pr-6 pt-6">
-          <RelatedVideos videos={randomVideos} error={popularError} />
+          <RelatedVideos
+            videos={relatedVideos}
+            loading={relatedLoading}
+            error={relatedError}
+          />
         </div>
       </div>
     </>

--- a/youtube-ari/src/utils/videoId.js
+++ b/youtube-ari/src/utils/videoId.js
@@ -1,0 +1,8 @@
+export function sanitizeVideoId(raw) {
+  if (!raw) return null;
+  // 정확히 11자라면 통과
+  if (/^[a-zA-Z0-9_-]{11}$/.test(raw)) return raw;
+  // 경로/쿼리에서 11자 토큰 추출
+  const m = raw.match(/([a-zA-Z0-9_-]{11})/);
+  return m ? m[1] : null;
+}


### PR DESCRIPTION
### ✅ 변경사항

#### youtube.js
- `searchSimilarVideos` 함수 추가 
  - 기준 영상의 제목/태그/카테고리를 기반으로 검색어 생성  
  - 같은 채널 영상 과다 노출 방지를 위한 `excludeChannelId` 옵션 지원  

#### useSimilarVideos.js
- 기준 영상 상세 정보를 조회하여 검색어 생성 
- `searchSimilarVideos` 호출로 유사 영상 목록 조회  
- `/videos` API로 상세 정보 보강 후 채널 이미지 포함하여 변환  

#### VideoDetail.jsx
- `useSimilarVideos` 훅 연동  
- 사이드바 영역에 메타데이터 기반 유사 영상 표시 
- 초기 데이터와 API 응답을 병합하는 로직으로 개선  

#### ChannelInfo.jsx
-  `channelImage`가 없을 경우 `default-avatar.png` 사용  
- 이미지 로딩 실패 시에도 `default-avatar.png`로 대체하도록 처리  

#### ScrollToTop.jsx
- 라우트 이동 시 스크롤 상단으로 초기화하는 ScrollToTop 컴포넌트 추가 
- 라우트 변경 시 `window.scrollTo(0,0)` 실행  
- 영상 상세 페이지 진입 시 스크롤 위치가 유지되던 문제 해결  

---
### ⭐ 이후 수정 사항
- 
