### PR TITLE
[Feat] 무한 스크롤 기능 구현 완료

### DIFF
--- a/youtube-ari/package-lock.json
+++ b/youtube-ari/package-lock.json
@@ -13,6 +13,7 @@
         "lucide-react": "^0.513.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-intersection-observer": "^9.16.0",
         "react-loading-skeleton": "^3.5.0",
         "react-router-dom": "^7.6.1"
       },
@@ -4567,6 +4568,21 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
+      "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-loading-skeleton": {

--- a/youtube-ari/package.json
+++ b/youtube-ari/package.json
@@ -15,6 +15,7 @@
     "lucide-react": "^0.513.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-intersection-observer": "^9.16.0",
     "react-loading-skeleton": "^3.5.0",
     "react-router-dom": "^7.6.1"
   },

--- a/youtube-ari/src/api/youtube.js
+++ b/youtube-ari/src/api/youtube.js
@@ -77,7 +77,7 @@ export const getVideoDetails = async (videoId) => {
 };
 
 // 검색 결과 동영상
-export const searchVideos = async (query, maxResults = 20, cursor = null) => {
+export const searchVideos = async (query, maxResults = 12, cursor = null) => {
   try {
     const response = await youtube.get("/search", {
       params: {

--- a/youtube-ari/src/api/youtube.js
+++ b/youtube-ari/src/api/youtube.js
@@ -14,7 +14,11 @@ const youtube = axios.create({
 });
 
 // 인기 동영상
-export const getPopularVideos = async (maxResults = 12, regionCode = "KR") => {
+export const getPopularVideos = async (
+  maxResults = 12,
+  regionCode = "KR",
+  cursor = null,
+) => {
   try {
     const response = await youtube.get("/videos", {
       params: {
@@ -22,9 +26,13 @@ export const getPopularVideos = async (maxResults = 12, regionCode = "KR") => {
         chart: "mostPopular",
         regionCode,
         maxResults,
+        pageToken: cursor || undefined,
       },
     });
-    return response.data.items;
+    return {
+      items: response.data.items ?? [],
+      nextCursor: response.data.nextPageToken ?? null,
+    };
   } catch (error) {
     console.error("Error fetching popular videos", error);
     throw error;

--- a/youtube-ari/src/api/youtube.js
+++ b/youtube-ari/src/api/youtube.js
@@ -77,7 +77,7 @@ export const getVideoDetails = async (videoId) => {
 };
 
 // 검색 결과 동영상
-export const searchVideos = async (query, maxResults = 20) => {
+export const searchVideos = async (query, maxResults = 20, cursor = null) => {
   try {
     const response = await youtube.get("/search", {
       params: {
@@ -85,9 +85,13 @@ export const searchVideos = async (query, maxResults = 20) => {
         q: query, // 사용자가 입력한 검색어
         type: "video", // 동영상만 검색하도록 지정 (채널, 재생목록 제외)
         maxResults,
+        pageToken: cursor || undefined,
       },
     });
-    return response.data.items;
+    return {
+      items: response.data.items ?? [],
+      nextCursor: response.data.nextPageToken ?? null,
+    };
   } catch (error) {
     console.error(`Error searching videos for "${query}":`, error);
     throw error;

--- a/youtube-ari/src/components/VideoGrid/VideoGrid.jsx
+++ b/youtube-ari/src/components/VideoGrid/VideoGrid.jsx
@@ -3,7 +3,7 @@ import { usePopularVideos } from "../../hooks/usePopularVideos";
 import VideoGridSkeleton from "./VideoGridSkeleton";
 
 const VideoGrid = () => {
-  const { videos, loading, error } = usePopularVideos();
+  const { videos, loading, error, hasMore, sentinelRef } = usePopularVideos();
 
   // 로딩 상태 UI (분리된 VideoGridSkeleton 컴포넌트 사용)
   if (loading) {
@@ -46,6 +46,23 @@ const VideoGrid = () => {
             ))}
         </div>
       </div>
+
+      {/* 무한스크롤 센티널 */}
+      {hasMore && (
+        <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
+      )}
+
+      {/* 추가 로딩 UI (다음 페이지 불러올 때) */}
+      {loading && videos.length > 0 && (
+        <div className="py-6 text-center text-gray-500">Loading more…</div>
+      )}
+
+      {/* 끝까지 다 불러왔을 때 표시 */}
+      {!hasMore && videos.length > 0 && (
+        <div className="py-6 text-center text-sm text-gray-400">
+          No more videos
+        </div>
+      )}
     </div>
   );
 };

--- a/youtube-ari/src/components/VideoGrid/VideoGrid.jsx
+++ b/youtube-ari/src/components/VideoGrid/VideoGrid.jsx
@@ -3,10 +3,11 @@ import { usePopularVideos } from "../../hooks/usePopularVideos";
 import VideoGridSkeleton from "./VideoGridSkeleton";
 
 const VideoGrid = () => {
-  const { videos, loading, error, hasMore, sentinelRef } = usePopularVideos();
+  const { videos, loadingInitial, loadingMore, error, hasMore, sentinelRef } =
+    usePopularVideos();
 
   // 로딩 상태 UI (분리된 VideoGridSkeleton 컴포넌트 사용)
-  if (loading) {
+  if (loadingInitial) {
     return (
       <div className="ml-[72px] pt-14">
         <VideoGridSkeleton count={12} />
@@ -53,9 +54,7 @@ const VideoGrid = () => {
       )}
 
       {/* 추가 로딩 UI (다음 페이지 불러올 때) */}
-      {loading && videos.length > 0 && (
-        <div className="py-6 text-center text-gray-500">Loading more…</div>
-      )}
+      {loadingMore && videos.length > 0 && <VideoGridSkeleton count={12} />}
 
       {/* 끝까지 다 불러왔을 때 표시 */}
       {!hasMore && videos.length > 0 && (

--- a/youtube-ari/src/components/common/ScrollToTop.jsx
+++ b/youtube-ari/src/components/common/ScrollToTop.jsx
@@ -2,11 +2,11 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 const ScrollToTop = () => {
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0); // 페이지 이동 시 스크롤 최상단으로 이동
-  }, [pathname]);
+    window.scrollTo(0, 0); // 페이지 이동 또는 쿼리 변경 시 스크롤 최상단으로 이동
+  }, [pathname, search]);
 
   return null;
 };

--- a/youtube-ari/src/hooks/usePopularVideos.js
+++ b/youtube-ari/src/hooks/usePopularVideos.js
@@ -1,57 +1,78 @@
 import { useEffect, useState } from "react";
+import { useInView } from "react-intersection-observer";
 import { getPopularVideos, getChannelImage } from "../api/youtube";
 import { transformVideo } from "../utils/transformVideoData";
 
-export function usePopularVideos() {
+export function usePopularVideos({ regionCode = "KR", pageSize = 12 } = {}) {
   const [videos, setVideos] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  const { ref: sentinelRef, inView } = useInView({
+    root: null,
+    rootMargin: "200px 0px",
+    threshold: 0,
+  });
+
+  const fetchPage = async (cursorParam = null) => {
+    try {
+      setLoading(true); // 로딩 시작
+
+      // 1. 인기 동영상 가져오기
+      const { items, nextCursor } = await getPopularVideos(
+        pageSize,
+        regionCode,
+        cursorParam,
+      );
+
+      // 2. 채널 이미지
+      const channelIds = [
+        ...new Set(items.map((it) => it?.snippet?.channelId).filter(Boolean)),
+      ];
+      const channelImages = await Promise.all(
+        channelIds.map((id) => getChannelImage(id)),
+      );
+      const channelImageMap = {};
+      channelIds.forEach((id, idx) => {
+        channelImageMap[id] = channelImages[idx] || "";
+      });
+
+      // 3. transform + append
+      const transformed = items.map((it) =>
+        transformVideo(it, channelImageMap[it?.snippet?.channelId] || ""),
+      );
+      setVideos((prev) => {
+        const seen = new Set(prev.map((v) => v.videoId));
+        const deduped = transformed.filter((v) => !seen.has(v.videoId));
+        return [...prev, ...deduped];
+      });
+
+      setCursor(nextCursor || null);
+      setHasMore(Boolean(nextCursor));
+      setError(null);
+    } catch (err) {
+      setError(err); // 에러 발생 시 에러 상태 설정
+      console.error("동영상 및 채널 이미지 로딩 실패:", err);
+      if (!cursorParam) setVideos([]); // 첫 로드 실패 시 초기화
+    } finally {
+      setLoading(false); // 로딩 종료
+    }
+  };
+
+  // 첫 페이지
   useEffect(() => {
-    const fetchAllVideosData = async () => {
-      try {
-        setLoading(true); // 로딩 시작
+    if (videos.length === 0) fetchPage(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-        // 1. 인기 동영상 데이터 가져오기 (raw 비디오 데이터)
-        const videoData = await getPopularVideos();
+  // 센티널 트리거
+  useEffect(() => {
+    if (inView && hasMore && !loading) {
+      fetchPage(cursor);
+    }
+  }, [inView, hasMore, loading, cursor]); // eslint-disable-line
 
-        // 2. 모든 동영상에서 채널 ID 추출 (중복 제거)
-        const channelIds = [
-          ...new Set(videoData.map((item) => item.snippet.channelId)),
-        ];
-
-        // 3. 각 채널 ID에 해당하는 채널 이미지를 병렬로 가져오기
-        const channelImagePromises = channelIds.map((id) =>
-          getChannelImage(id),
-        );
-        const channelImages = await Promise.all(channelImagePromises);
-
-        // 4. 채널 ID와 채널 이미지 URL을 매핑하는 객체 생성
-        const channelImageMap = {};
-        channelIds.forEach((id, index) => {
-          channelImageMap[id] = channelImages[index];
-        });
-
-        // 5. 비디오 데이터와 채널 이미지를 결합하고 `transformVideo`를 사용하여 최종 형태로 변환
-        const transformedVideos = videoData.map((item) => {
-          const channelImageUrl = channelImageMap[item.snippet.channelId] || ""; // 해당 채널의 이미지 URL
-          return transformVideo(item, channelImageUrl); // `transformVideo`에 raw 비디오와 채널 이미지 URL 전달
-        });
-
-        setVideos(transformedVideos); // 변환된 동영상 데이터를 상태에 저장
-        setError(null); // 성공 시 에러 상태 초기화
-      } catch (err) {
-        setError(err); // 에러 발생 시 에러 상태 설정
-        console.error("동영상 및 채널 이미지 로딩 실패:", err);
-        setVideos([]); // 에러 발생 시 비디오 목록 초기화
-      } finally {
-        setLoading(false); // 로딩 종료
-      }
-    };
-
-    fetchAllVideosData();
-  }, []); // 의존성 배열이 비어있으므로 컴포넌트 마운트 시 한 번만 실행
-
-  // 동영상 데이터, 로딩 상태, 에러 상태를 반환
-  return { videos, loading, error };
+  return { videos, loading, error, hasMore, sentinelRef };
 }

--- a/youtube-ari/src/hooks/usePopularVideos.js
+++ b/youtube-ari/src/hooks/usePopularVideos.js
@@ -7,7 +7,8 @@ export function usePopularVideos({ regionCode = "KR", pageSize = 12 } = {}) {
   const [videos, setVideos] = useState([]);
   const [cursor, setCursor] = useState(null);
   const [hasMore, setHasMore] = useState(true);
-  const [loading, setLoading] = useState(true);
+  const [loadingInitial, setLoadingInitial] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
 
   const { ref: sentinelRef, inView } = useInView({
@@ -17,9 +18,12 @@ export function usePopularVideos({ regionCode = "KR", pageSize = 12 } = {}) {
   });
 
   const fetchPage = async (cursorParam = null) => {
-    try {
-      setLoading(true); // 로딩 시작
+    // 초기/추가 로딩 구분
+    const isInitial = videos.length === 0 && !cursorParam;
+    isInitial ? setLoadingInitial(true) : setLoadingMore(true);
 
+    try {
+      setError(null);
       // 1. 인기 동영상 가져오기
       const { items, nextCursor } = await getPopularVideos(
         pageSize,
@@ -57,7 +61,7 @@ export function usePopularVideos({ regionCode = "KR", pageSize = 12 } = {}) {
       console.error("동영상 및 채널 이미지 로딩 실패:", err);
       if (!cursorParam) setVideos([]); // 첫 로드 실패 시 초기화
     } finally {
-      setLoading(false); // 로딩 종료
+      isInitial ? setLoadingInitial(false) : setLoadingMore(false); // 로딩 종료
     }
   };
 
@@ -69,10 +73,10 @@ export function usePopularVideos({ regionCode = "KR", pageSize = 12 } = {}) {
 
   // 센티널 트리거
   useEffect(() => {
-    if (inView && hasMore && !loading) {
+    if (inView && hasMore && !loadingMore && !loadingInitial) {
       fetchPage(cursor);
     }
-  }, [inView, hasMore, loading, cursor]); // eslint-disable-line
+  }, [inView, hasMore, loadingMore, loadingInitial, cursor]); // eslint-disable-line
 
-  return { videos, loading, error, hasMore, sentinelRef };
+  return { videos, loadingInitial, loadingMore, error, hasMore, sentinelRef };
 }

--- a/youtube-ari/src/hooks/useSearchVideos.js
+++ b/youtube-ari/src/hooks/useSearchVideos.js
@@ -1,80 +1,102 @@
 import { useState, useEffect } from "react";
+import { useInView } from "react-intersection-observer";
 import { searchVideos, getChannelImage, getVideoDetails } from "../api/youtube";
 import { transformVideo } from "../utils/transformVideoData";
 
 // 주어진 검색어에 대한 YouTube 동영상 검색 결과를 가져오는 커스텀 훅.
 
-export const useSearchVideos = (searchQuery) => {
+export const useSearchVideos = (searchQuery, pageSize = 20) => {
   const [videos, setVideos] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  const { ref: sentinelRef, inView } = useInView({
+    root: null,
+    rootMargin: "200px 0px",
+    threshold: 0,
+  });
+
+  const fetchPage = async (cursorParam = null, replace = false) => {
+    if (!searchQuery) {
+      setVideos([]);
+      setHasMore(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      // 1. 검색 API 호출
+      const { items, nextCursor } = await searchVideos(
+        searchQuery,
+        pageSize,
+        cursorParam,
+      );
+
+      // 2. 상세정보/채널이미지 병합
+      const videoPromises = items.map(async (video) => {
+        if (video.id.kind === "youtube#video") {
+          const channelId = video.snippet.channelId;
+          const videoId = video.id.videoId;
+          const [channelImage, videoDetails] = await Promise.all([
+            getChannelImage(channelId),
+            getVideoDetails(videoId),
+          ]);
+          const combined = {
+            ...video,
+            snippet: {
+              ...video.snippet,
+              ...(videoDetails?.snippet && {
+                title: videoDetails.snippet.title,
+                description: videoDetails.snippet.description,
+                publishedAt: videoDetails.snippet.publishedAt,
+                channelTitle: videoDetails.snippet.channelTitle,
+                channelId: videoDetails.snippet.channelId,
+                thumbnails: videoDetails.snippet.thumbnails,
+              }),
+            },
+            statistics: videoDetails?.statistics ?? video.statistics,
+          };
+          return transformVideo(combined, channelImage);
+        }
+        return null;
+      });
+
+      const detailedVideos = (await Promise.all(videoPromises)).filter(Boolean);
+
+      // 3. 상태 업데이트
+      setVideos((prev) =>
+        replace ? detailedVideos : [...prev, ...detailedVideos],
+      );
+      setCursor(nextCursor || null);
+      setHasMore(Boolean(nextCursor));
+    } catch (err) {
+      console.error("Failed to fetch search results:", err);
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 검색어 변경 시 초기화 + 첫 페이지
   useEffect(() => {
-    const fetchResults = async () => {
-      // 검색어가 없으면 로딩 상태를 해제하고 비디오를 비움
-      if (!searchQuery) {
-        setLoading(false);
-        setVideos([]);
-        return;
-      }
-
-      setLoading(true); // 데이터 로딩 시작
-      setError(null); // 이전 에러 초기화
-      try {
-        // 1. YouTube Data API의 search 엔드포인트를 사용하여 초기 검색 결과 가져오기
-        const searchData = await searchVideos(searchQuery);
-
-        // 2. 각 비디오에 대한 추가 정보 (채널 이미지, 조회수) 비동기적으로 가져오기
-        const videosWithDetailsPromises = searchData.map(async (video) => {
-          // 여기서는 비디오 (kind: "youtube#video")만 처리하고, 추가 정보를 가져옴
-          if (video.id.kind === "youtube#video") {
-            const channelId = video.snippet.channelId;
-            const videoId = video.id.videoId;
-
-            // 채널 이미지와 비디오 상세 정보를 동시에 가져옴
-            const [channelImage, videoDetails] = await Promise.all([
-              getChannelImage(channelId),
-              getVideoDetails(videoId),
-            ]);
-
-            // search API 데이터 + 상세 API 데이터(snippet, statistics)를 합쳐서 전달
-            const combinedVideoData = {
-              ...video,
-              // 상세 snippet으로 덮어써서 잘린 설명 대신 전체 설명 사용
-              snippet: {
-                ...video.snippet,
-                ...(videoDetails?.snippet && {
-                  title: videoDetails.snippet.title,
-                  description: videoDetails.snippet.description,
-                  publishedAt: videoDetails.snippet.publishedAt,
-                  channelTitle: videoDetails.snippet.channelTitle,
-                  channelId: videoDetails.snippet.channelId,
-                  thumbnails: videoDetails.snippet.thumbnails,
-                }),
-              },
-              statistics: videoDetails?.statistics ?? video.statistics, // 통계 정보 병합
-            };
-            return transformVideo(combinedVideoData, channelImage);
-          }
-          return null; // 비디오가 아닌 항목은 null 반환
-        });
-
-        // 모든 비디오의 상세 정보가 로드될 때까지 기다린 후, null 값 필터링
-        const detailedVideos = (
-          await Promise.all(videosWithDetailsPromises)
-        ).filter(Boolean);
-        setVideos(detailedVideos);
-      } catch (err) {
-        console.error("Failed to fetch search results:", err);
-        setError(err); // 에러 객체를 그대로 저장하여 더 자세한 정보 제공
-      } finally {
-        setLoading(false); // 로딩 완료
-      }
-    };
-
-    fetchResults();
-    // searchQuery가 변경될 때마다 다시 검색을 수행하도록 의존성 배열에 추가
+    setVideos([]);
+    setCursor(null);
+    setHasMore(true);
+    if (searchQuery) {
+      fetchPage(null, true);
+    }
   }, [searchQuery]);
 
-  return { videos, loading, error };
+  // 센티널이 보이면 다음 페이지
+  useEffect(() => {
+    if (inView && hasMore && !loading) {
+      fetchPage(cursor);
+    }
+  }, [inView, hasMore, loading, cursor]); // eslint-disable-line
+
+  return { videos, loading, error, hasMore, sentinelRef };
 };

--- a/youtube-ari/src/hooks/useSearchVideos.js
+++ b/youtube-ari/src/hooks/useSearchVideos.js
@@ -5,11 +5,12 @@ import { transformVideo } from "../utils/transformVideoData";
 
 // 주어진 검색어에 대한 YouTube 동영상 검색 결과를 가져오는 커스텀 훅.
 
-export const useSearchVideos = (searchQuery, pageSize = 20) => {
+export const useSearchVideos = (searchQuery, pageSize = 12) => {
   const [videos, setVideos] = useState([]);
   const [cursor, setCursor] = useState(null);
   const [hasMore, setHasMore] = useState(true);
-  const [loading, setLoading] = useState(true);
+  const [loadingInitial, setLoadingInitial] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
 
   const { ref: sentinelRef, inView } = useInView({
@@ -25,8 +26,10 @@ export const useSearchVideos = (searchQuery, pageSize = 20) => {
       return;
     }
 
+    const isInitial = replace || (videos.length === 0 && !cursorParam);
+    isInitial ? setLoadingInitial(true) : setLoadingMore(true);
+
     try {
-      setLoading(true);
       setError(null);
 
       // 1. 검색 API 호출
@@ -77,7 +80,7 @@ export const useSearchVideos = (searchQuery, pageSize = 20) => {
       console.error("Failed to fetch search results:", err);
       setError(err);
     } finally {
-      setLoading(false);
+      isInitial ? setLoadingInitial(false) : setLoadingMore(false);
     }
   };
 
@@ -93,10 +96,10 @@ export const useSearchVideos = (searchQuery, pageSize = 20) => {
 
   // 센티널이 보이면 다음 페이지
   useEffect(() => {
-    if (inView && hasMore && !loading) {
+    if (inView && hasMore && !loadingMore && !loadingInitial) {
       fetchPage(cursor);
     }
-  }, [inView, hasMore, loading, cursor]); // eslint-disable-line
+  }, [inView, hasMore, loadingMore, loadingInitial, cursor]); // eslint-disable-line
 
-  return { videos, loading, error, hasMore, sentinelRef };
+  return { videos, loadingMore, loadingInitial, error, hasMore, sentinelRef };
 };

--- a/youtube-ari/src/pages/SearchResults.jsx
+++ b/youtube-ari/src/pages/SearchResults.jsx
@@ -8,7 +8,8 @@ const SearchResults = () => {
   // URL에서 'search_query' 쿼리 파라미터(검색어)를 추출
   const queryParams = new URLSearchParams(location.search);
   const searchQuery = queryParams.get("search_query");
-  const { videos, loading, error } = useSearchVideos(searchQuery);
+  const { videos, loading, error, hasMore, sentinelRef } =
+    useSearchVideos(searchQuery);
 
   // 로딩 상태 UI
   if (loading) {
@@ -51,6 +52,23 @@ const SearchResults = () => {
             ))}
         </div>
       </div>
+
+      {/* 무한스크롤 센티널 */}
+      {hasMore && (
+        <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
+      )}
+
+      {/* 추가 로딩 UI (다음 페이지 불러올 때) */}
+      {loading && videos.length > 0 && (
+        <div className="py-6 text-center text-gray-500">Loading more…</div>
+      )}
+
+      {/* 끝까지 다 불러왔을 때 표시 */}
+      {!hasMore && videos.length > 0 && (
+        <div className="py-6 text-center text-sm text-gray-400">
+          No more videos
+        </div>
+      )}
     </div>
   );
 };

--- a/youtube-ari/src/pages/SearchResults.jsx
+++ b/youtube-ari/src/pages/SearchResults.jsx
@@ -8,11 +8,11 @@ const SearchResults = () => {
   // URL에서 'search_query' 쿼리 파라미터(검색어)를 추출
   const queryParams = new URLSearchParams(location.search);
   const searchQuery = queryParams.get("search_query");
-  const { videos, loading, error, hasMore, sentinelRef } =
+  const { videos, loadingMore, loadingInitial, error, hasMore, sentinelRef } =
     useSearchVideos(searchQuery);
 
   // 로딩 상태 UI
-  if (loading) {
+  if (loadingInitial) {
     return (
       <div className="ml-[72px] pt-14">
         <VideoGridSkeleton count={12} />
@@ -59,9 +59,7 @@ const SearchResults = () => {
       )}
 
       {/* 추가 로딩 UI (다음 페이지 불러올 때) */}
-      {loading && videos.length > 0 && (
-        <div className="py-6 text-center text-gray-500">Loading more…</div>
-      )}
+      {loadingMore && videos.length > 0 && <VideoGridSkeleton count={12} />}
 
       {/* 끝까지 다 불러왔을 때 표시 */}
       {!hasMore && videos.length > 0 && (


### PR DESCRIPTION
### ✅ 변경사항
#### 1. `Search` 및 `Home` 페이지 무한 스크롤 구현
- `react-intersection-observer` 패키지 추가
- `getPopularVideos`, `searchVideos` API에 `pageToken(cursor)` 지원 추가
- `usePopularVideos`, `useSearchVideos` 훅을 무한 스크롤 형태로 리팩토링

#### 2. UX 개선 및 버그 수정
- `usePopularVideos`, `useSearchVideos` 훅에서 로딩 상태 분리
  - `loadingInitial`: 첫 페이지 로딩
  - `loadingMore`: 추가 페이지 로딩
  - 추가 로딩 시 기존 리스트 유지 + 하단에만 `VideoGridSkeleton` UI 표시
- `ScrollToTop` 컴포넌트에서 `pathname`뿐 아니라 `search` 파라미터도 감시하도록 수정
  - 검색어 변경 시 스크롤이 최상단으로 즉시 이동
  - `smooth` 옵션은 사용하지 않고 유튜브와 동일하게 즉시 이동 처리

---
### ⭐ 이후 수정 사항
- 
